### PR TITLE
Disable too many draws for now

### DIFF
--- a/bytedesign.py
+++ b/bytedesign.py
@@ -146,6 +146,7 @@ class Designer(Turtle):
         self.centerpiece(s - (1.2 * scale), a, scale)
 
 def main():
+    "this bufferss too many messages"
     t = Designer()
     t.speed(0)
     t.hideturtle()

--- a/dturtle.ipynb
+++ b/dturtle.ipynb
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,39 +123,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "616f82c063204d26ab851592d3687e16",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(DualCanvasWidget(status='Not yet rendered'), Text(value='Not yet rendered', description='status…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "ename": "AttributeError",
-     "evalue": "'Designer' object has no attribute 'up'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-2-ad46b8b149ce>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mbytedesign\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmain\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/test_notebook/bytedesign.py\u001b[0m in \u001b[0;36mmain\u001b[0;34m()\u001b[0m\n\u001b[1;32m    153\u001b[0m \u001b[0;31m#     t.getscreen().tracer(0)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    154\u001b[0m \u001b[0;31m#     at = clock()\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 155\u001b[0;31m     \u001b[0mt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdesign\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mposition\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    156\u001b[0m \u001b[0;31m#     et = clock()\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    157\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0;31m#\"runtime: %.2f sec.\" % (et-at)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/test_notebook/bytedesign.py\u001b[0m in \u001b[0;36mdesign\u001b[0;34m(self, homePos, scale)\u001b[0m\n\u001b[1;32m     32\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     33\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mdesign\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mhomePos\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mscale\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 34\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mup\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     35\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m5\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mforward\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m64.65\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mscale\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'Designer' object has no attribute 'up'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "bytedesign.main()"
+    "# You have to initialize the designer in once cell\n",
+    "# and start design() in another cell, otherwise too many messages get buffered.\n",
+    "designer = bytedesign.Designer()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "designer.speed(0)\n",
+    "#designer.speed_stamp = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "designer.hideturtle()\n",
+    "designer.draw_limit, designer.draw_count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "designer.screen.auto_flush = False\n",
+    "\n",
+    "# For now limit the number ob draw operations\n",
+    "designer.draw_limit = 300\n",
+    "\n",
+    "designer.design(designer.position, 2)\n",
+    "designer.screen.flush()\n",
+    "designer.screen.auto_flush = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "designer.speed_stamp"
    ]
   },
   {
@@ -182,7 +201,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The bytedesign example sends too many draw operations too fast.
This causes the communication between Python and Javascript to break down.

I will try to fix jp_proxy_widget so it will handle this case tomorrow.

For now I have added a counter which ignores all draws past a specified limit.
Please try to get the illustration working up to the draw limit.

Thanks!  -- Aaron Watters